### PR TITLE
Move httpRequest to top level

### DIFF
--- a/lib/stack-driver-transform.js
+++ b/lib/stack-driver-transform.js
@@ -3,13 +3,13 @@
 const { Transform } = require('stream');
 
 function processContext({ request, headers, status }) {
-    if (request && headers) {
+    if (request) {
         return {
-            method: request.method,
-            url: request.url,
-            responseStatusCode: status,
-            referrer: headers.referer,
-            userAgent: headers['user-agent'],
+            requestMethod: request.method,
+            requestUrl: request.url,
+            status,
+            referrer: headers && headers.referer,
+            userAgent: headers && headers['user-agent'],
             remoteIp: request.ip
         };
     }
@@ -51,7 +51,7 @@ class StackDriverTransform extends Transform {
 
         if (ctx) {
             chunk.context.user = processUser(ctx);
-            chunk.context.httpRequest = processContext(ctx);
+            chunk.httpRequest = processContext(ctx);
             delete chunk.context.ctx;
         }
 

--- a/test/lib/stack-driver-transform.tests.js
+++ b/test/lib/stack-driver-transform.tests.js
@@ -181,10 +181,10 @@ describe('stack-driver-transform', () => {
             return pusher(logObjects)
                 .then(results => {
                     assert.equal(results.length, 1);
-                    assert.deepEqual(results[0].context.httpRequest, {
-                        method: 'the-method',
-                        url: 'the-url',
-                        responseStatusCode: 'the-status',
+                    assert.deepEqual(results[0].httpRequest, {
+                        requestMethod: 'the-method',
+                        requestUrl: 'the-url',
+                        status: 'the-status',
                         referrer: 'the-referrer',
                         userAgent: 'the-user-agent',
                         remoteIp: 'the-ip'


### PR DESCRIPTION
[LogEntry#HttpRequest][1] documentation. I tried this format in `api-router` and it produced a bit nicer output in logs.

Unfortunately we still miss some important information like `latency`, `requestSize` and  `responseSize` but api-router logs cover some of that, so this is less important now.

[1]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest