### PR TITLE
Use jsonPayload instead of context

### DIFF
--- a/lib/make-logger.js
+++ b/lib/make-logger.js
@@ -3,8 +3,8 @@
 function noop() {}
 
 function makeLoggerForSeverity(severity, stream) {
-    return function(message, context) {
-        stream.write({ severity, message, context, eventTime: new Date().toISOString() });
+    return function(message, jsonPayload) {
+        stream.write({ jsonPayload, severity, message, eventTime: new Date().toISOString() });
     };
 }
 

--- a/test/lib/make-logger.test.js
+++ b/test/lib/make-logger.test.js
@@ -64,7 +64,7 @@ describe('makeLogger', () => {
         assert.deepEqual(streams[0].stream.buffer, [{
             severity: 'debug',
             message: 'Hello, world!',
-            context: 'context',
+            jsonPayload: 'context',
             eventTime: 'a-time'
         }]);
     });
@@ -72,9 +72,9 @@ describe('makeLogger', () => {
     it('does not log a message or context to the designated stream when the severity is disabled', () => {
         const log = makeLogger(streams, 'info');
 
-        log.debug('some debug', 'debug context');
-        log.info('some info', 'info context');
-        log.error('some error', 'error context');
+        log.debug('some debug', { detail: 'debug detail' });
+        log.info('some info', { detail: 'info detail' });
+        log.error('some error', { detail: 'error detail' });
 
         assert.equal(streams[0].stream.buffer.length, 0);
         assert.equal(streams[1].stream.buffer.length, 1);
@@ -83,14 +83,14 @@ describe('makeLogger', () => {
         assert.deepEqual(streams[1].stream.buffer, [{
             severity: 'info',
             message: 'some info',
-            context: 'info context',
+            jsonPayload:  { detail: 'info detail' },
             eventTime: 'a-time'
         }]);
 
         assert.deepEqual(streams[2].stream.buffer, [{
             severity: 'error',
             message: 'some error',
-            context: 'error context',
+            jsonPayload: { detail: 'error detail' },
             eventTime: 'a-time'
         }]);
     });


### PR DESCRIPTION
Keep standardising according to updated spec: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest