### PR TITLE
remove koa context knowledge from stackdriver logger

### DIFF
--- a/lib/stack-driver-transform.js
+++ b/lib/stack-driver-transform.js
@@ -2,31 +2,6 @@
 
 const { Transform } = require('stream');
 
-function processContext({ request, headers, status }) {
-    if (request) {
-        return {
-            requestMethod: request.method,
-            requestUrl: request.url,
-            status,
-            referrer: headers && headers.referer,
-            userAgent: headers && headers['user-agent'],
-            remoteIp: request.ip
-        };
-    }
-}
-
-function processUser({ authorized, authorizedModel }) {
-    if (!authorized) {
-        return null;
-    }
-
-    if (typeof authorizedModel === 'object' && authorizedModel.modelName) {
-        authorizedModel = authorizedModel.modelName;
-    }
-
-    return `${authorizedModel}:${authorized.id}${authorized.name ? ` (${authorized.name})` : ''}`;
-}
-
 class StackDriverTransform extends Transform {
     constructor(options = {}) {
         super(Object.assign({}, options, { objectMode: true }));
@@ -36,7 +11,7 @@ class StackDriverTransform extends Transform {
     _transform(chunk, encoding, callback) {
         chunk.serviceContext = Object.assign({}, this.serviceContext);
 
-        const { error, ctx } = chunk.context || {};
+        const error = chunk.error;
 
         if (error) {
             if (chunk.message) {
@@ -47,12 +22,6 @@ class StackDriverTransform extends Transform {
             chunk.message += error.stack || `${error.name} ${error.message}`;
         } else if (!chunk.message) {
             chunk.message = 'No message for this log.';
-        }
-
-        if (ctx) {
-            chunk.context.user = processUser(ctx);
-            chunk.httpRequest = processContext(ctx);
-            delete chunk.context.ctx;
         }
 
         callback(null, chunk);

--- a/test/lib/stack-driver-transform.tests.js
+++ b/test/lib/stack-driver-transform.tests.js
@@ -77,7 +77,7 @@ describe('stack-driver-transform', () => {
     });
 
     it('uses the error stack to make a message when an error is given', () => {
-        return pusher([{ context: { error: { stack: 'the error stack' } } }])
+        return pusher([{ error: { stack: 'the error stack' } }])
             .then(results => {
                 assert.equal(results.length, 1);
                 assert.equal(results[0].message, 'the error stack');
@@ -85,7 +85,7 @@ describe('stack-driver-transform', () => {
     });
 
     it('prepends a message to the error stack when both are given', () => {
-        return pusher([{ message: 'a message', context: { error: { stack: 'the error stack' } } }])
+        return pusher([{ message: 'a message', error: { stack: 'the error stack' } }])
             .then(results => {
                 assert.equal(results.length, 1);
                 assert.equal(results[0].message, 'a message the error stack');
@@ -93,7 +93,7 @@ describe('stack-driver-transform', () => {
     });
 
     it('uses the error name and message when it has no stack', () => {
-        return pusher([{ context: { error: { name: 'error name', message: 'error message' } } }])
+        return pusher([{ error: { name: 'error name', message: 'error message' } }])
             .then(results => {
                 assert.equal(results.length, 1);
                 assert.equal(results[0].message, 'error name error message');
@@ -101,95 +101,10 @@ describe('stack-driver-transform', () => {
     });
 
     it('prepends a message to the error name and message both are given and the error has no stack', () => {
-        return pusher([{ message: 'a message', context: { error: { name: 'error name', message: 'error message' } } }])
+        return pusher([{ message: 'a message', error: { name: 'error name', message: 'error message' } }])
             .then(results => {
                 assert.equal(results.length, 1);
                 assert.equal(results[0].message, 'a message error name error message');
             });
-    });
-
-    it('removes the koa context when found', () => {
-        return pusher([{ context: { ctx: {} } }])
-            .then(results => {
-                assert.equal(results.length, 1);
-                assert.strictEqual(results[0].context.ctx, undefined);
-            });
-    });
-
-    describe('user', () => {
-        it('does not append a user when no koa context is found', () => {
-            return pusher([{ context: {} }])
-                .then(results => {
-                    assert.equal(results.length, 1);
-                    assert.strictEqual(results[0].context.user, undefined);
-                });
-        });
-
-        it('sets the user to null when not authorized', () => {
-            return pusher([{ context: { ctx: {} } }])
-                .then(results => {
-                    assert.equal(results.length, 1);
-                    assert.strictEqual(results[0].context.user, null);
-                });
-        });
-
-        it('distils and appends a user from the koa context when possible', () => {
-            return pusher([{ context: { ctx: { authorized: { id: 'auth-id' }, authorizedModel: 'auth-model' } } }])
-                .then(results => {
-                    assert.equal(results.length, 1);
-                    assert.equal(results[0].context.user, 'auth-model:auth-id');
-                });
-        });
-
-        it('adds the auth name when possible', () => {
-            return pusher([{ context: { ctx: { authorized: { id: 'auth-id', name: 'auth-name' }, authorizedModel: 'auth-model' } } }])
-                .then(results => {
-                    assert.equal(results.length, 1);
-                    assert.equal(results[0].context.user, 'auth-model:auth-id (auth-name)');
-                });
-        });
-    });
-
-    describe('http requests', () => {
-        it('does not append httpRequest when a request or headers from a koa context are missing', () => {
-            return pusher([{ context: { ctx: {} } }, { context: { ctx: { request: {} } } }])
-                .then(results => {
-                    assert.equal(results.length, 2);
-                    assert.strictEqual(results[0].context.httpRequest, undefined);
-                    assert.strictEqual(results[1].context.httpRequest, undefined);
-                });
-        });
-
-        it('adds selected information about a request', () => {
-            const logObjects = [{
-                context: {
-                    ctx: {
-                        status: 'the-status',
-                        headers: {
-                            'user-agent': 'the-user-agent',
-                            referer: 'the-referrer'
-                        },
-                        request: {
-                            method: 'the-method',
-                            url: 'the-url',
-                            ip: 'the-ip'
-                        }
-                    }
-                }
-            }];
-
-            return pusher(logObjects)
-                .then(results => {
-                    assert.equal(results.length, 1);
-                    assert.deepEqual(results[0].httpRequest, {
-                        requestMethod: 'the-method',
-                        requestUrl: 'the-url',
-                        status: 'the-status',
-                        referrer: 'the-referrer',
-                        userAgent: 'the-user-agent',
-                        remoteIp: 'the-ip'
-                    });
-                });
-        });
     });
 });


### PR DESCRIPTION
- `chunk.context` does not exist after #9 merge
- logger can be used not only in context of koa request and it make sense to NOT have this logic here